### PR TITLE
File Management Sidebar

### DIFF
--- a/dialogs/new-file-dialog.css
+++ b/dialogs/new-file-dialog.css
@@ -1,0 +1,120 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f7;
+  --fg: #1e1e1e;
+  --border: #dcdcdc;
+  --hover: #e8e8ec;
+  --active: #dbe6ff;
+  --active-fg: #1a3d8f;
+  --muted: #7a7a7a;
+  --danger: #c0392b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #202124;
+    --fg: #e8e8e8;
+    --border: #35363a;
+    --hover: #2b2c30;
+    --active: #2a3b5c;
+    --active-fg: #9cc0ff;
+    --muted: #9a9a9a;
+    --danger: #ff6b5e;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg);
+  font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.new-file-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100vh;
+  padding: 16px;
+  margin: 0;
+}
+
+label {
+  font-weight: 600;
+}
+
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 8px;
+  background: var(--bg);
+}
+
+.input-row:focus-within {
+  border-color: var(--active-fg);
+}
+
+#name-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  padding: 8px 0;
+  outline: none;
+}
+
+.extension-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.feedback {
+  margin: 0;
+  min-height: 32px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.feedback.danger {
+  color: var(--danger);
+}
+
+.actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.actions button {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--hover);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.actions button:hover {
+  background: var(--active);
+}
+
+#create-btn {
+  background: var(--active);
+  color: var(--active-fg);
+  font-weight: 600;
+  border-color: var(--active-fg);
+}

--- a/dialogs/new-file-dialog.html
+++ b/dialogs/new-file-dialog.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self';"
+    />
+    <title>New File</title>
+    <link rel="stylesheet" href="new-file-dialog.css" />
+  </head>
+  <body>
+    <form id="new-file-form" class="new-file-dialog">
+      <label for="name-input">File name</label>
+      <div class="input-row">
+        <input id="name-input" type="text" autocomplete="off" spellcheck="false" />
+        <span class="extension-label">.excalidraw</span>
+      </div>
+      <p id="feedback" class="feedback"></p>
+      <div class="actions">
+        <button type="button" id="cancel-btn">Cancel</button>
+        <button type="submit" id="create-btn">Create</button>
+      </div>
+    </form>
+    <script src="new-file-dialog.js"></script>
+  </body>
+</html>

--- a/dialogs/new-file-dialog.js
+++ b/dialogs/new-file-dialog.js
@@ -1,0 +1,94 @@
+(function () {
+  const params = new URLSearchParams(location.search);
+  const defaultName = params.get('default') || 'Untitled';
+
+  const form = document.getElementById('new-file-form');
+  const input = document.getElementById('name-input');
+  const feedback = document.getElementById('feedback');
+  const cancelBtn = document.getElementById('cancel-btn');
+
+  input.placeholder = defaultName;
+
+  // Mirrors index.js's sanitizeBaseName() so the live preview matches what
+  // the main process will actually do with the name.
+  const ILLEGAL_FILENAME_CHARS_REGEX = /[\\/:*?"<>|\x00-\x1F]/g;
+  const WINDOWS_RESERVED_NAMES = new Set([
+    'CON',
+    'PRN',
+    'AUX',
+    'NUL',
+    'COM1',
+    'COM2',
+    'COM3',
+    'COM4',
+    'COM5',
+    'COM6',
+    'COM7',
+    'COM8',
+    'COM9',
+    'LPT1',
+    'LPT2',
+    'LPT3',
+    'LPT4',
+    'LPT5',
+    'LPT6',
+    'LPT7',
+    'LPT8',
+    'LPT9',
+  ]);
+  const MAX_BASENAME_LENGTH = 150;
+
+  function sanitizeBaseName(name) {
+    let result = String(name || '').replace(ILLEGAL_FILENAME_CHARS_REGEX, '');
+    result = result.replace(/\.excalidraw$/i, '');
+    result = result.trim().replace(/[. ]+$/, '');
+    if (!result) return '';
+    if (WINDOWS_RESERVED_NAMES.has(result.toUpperCase())) return '';
+    return result.slice(0, MAX_BASENAME_LENGTH);
+  }
+
+  let existingNames = [];
+
+  function updateFeedback() {
+    const sanitized = sanitizeBaseName(input.value);
+
+    if (!sanitized) {
+      feedback.textContent = `Will use default name: ${defaultName}.excalidraw`;
+      feedback.classList.remove('danger');
+      return;
+    }
+
+    if (existingNames.includes(sanitized.toLowerCase())) {
+      feedback.textContent = `Will be saved as: ${sanitized}.excalidraw — a file with this name exists, will be saved as "${sanitized} (2).excalidraw"`;
+      feedback.classList.add('danger');
+    } else {
+      feedback.textContent = `Will be saved as: ${sanitized}.excalidraw`;
+      feedback.classList.remove('danger');
+    }
+  }
+
+  input.addEventListener('input', updateFeedback);
+  updateFeedback();
+  input.focus();
+
+  window.newFileDialogAPI.getExistingNames().then((names) => {
+    existingNames = names || [];
+    updateFeedback();
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    window.newFileDialogAPI.submit(input.value);
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    window.newFileDialogAPI.cancel();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      window.newFileDialogAPI.cancel();
+    }
+  });
+})();

--- a/dialogs/new-file-preload.js
+++ b/dialogs/new-file-preload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('newFileDialogAPI', {
+  submit: (name) => ipcRenderer.invoke('dialog:new-file-submit', name),
+  cancel: () => ipcRenderer.invoke('dialog:new-file-cancel'),
+  getExistingNames: () => ipcRenderer.invoke('dialog:new-file-getExistingNames'),
+});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-const { app, BrowserWindow, Menu, Notification, dialog, screen, shell } = require('electron');
+const { app, BrowserWindow, WebContentsView, Menu, Notification, dialog, screen, shell, ipcMain } = require('electron');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const GITHUB_OWNER = 'pgkt04';
 const GITHUB_REPO = 'excalidraw-desktop';
@@ -9,11 +10,18 @@ const RELEASES_PAGE_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/rel
 const UPDATE_STATE_FILE = 'update-state.json';
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const WINDOW_STATE_FILE = 'window-state.json';
+const WORKSPACE_STATE_FILE = 'workspace-state.json';
 const DEFAULT_WINDOW_BOUNDS = { width: 1300, height: 900 };
+const SIDEBAR_WIDTH = 260;
 
 // Track file paths requested before the app is ready (macOS open-file can fire early)
 let pendingFilePath = null;
 let updateCheckPromise = null;
+
+// Per-window state: { win, contentView, sidebarView, sidebarVisible, workspaceDir, currentFilePath, lastSavedSnapshotHash, forceClosing }
+const windowState = new Map();
+// Per-directory watchers, refcounted across windows: dir -> { watcher, subscribers: Set<winId>, debounceTimer }
+const workspaceWatchers = new Map();
 
 function normalizeVersion(version) {
   return String(version || '')
@@ -106,6 +114,27 @@ function saveWindowState(win) {
     );
   } catch (err) {
     console.error('Failed to save window state:', err);
+  }
+}
+
+function getWorkspaceStatePath() {
+  return path.join(app.getPath('userData'), WORKSPACE_STATE_FILE);
+}
+
+function loadWorkspaceState() {
+  try {
+    return JSON.parse(fs.readFileSync(getWorkspaceStatePath(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveWorkspaceState(state) {
+  try {
+    fs.mkdirSync(app.getPath('userData'), { recursive: true });
+    fs.writeFileSync(getWorkspaceStatePath(), JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error('Failed to save workspace state:', err);
   }
 }
 
@@ -267,62 +296,584 @@ function getFilePathFromArgv(argv) {
   return null;
 }
 
-// Read a .excalidraw file and inject its contents into the window via localStorage
-async function loadFileIntoWindow(win, filePath) {
-  try {
-    const raw = fs.readFileSync(filePath, 'utf8');
-    const data = JSON.parse(raw);
+function hashData(data) {
+  return crypto.createHash('sha256').update(JSON.stringify(data)).digest('hex');
+}
 
-    const elements = data.elements || [];
-    const appState = data.appState || {};
-    const files = data.files || {};
+function contentWebContentsFor(win) {
+  const state = windowState.get(win.id);
+  return state ? state.contentView.webContents : win.webContents;
+}
 
-    // Wait for the page to finish loading before injecting
-    const inject = () => {
-      win.webContents.executeJavaScript(`
+// executeJavaScript() can occasionally never settle (neither resolve nor reject) —
+// e.g. when called in close proximity to another in-flight call on the same
+// webContents, such as right after a reload triggered by loadFileIntoWindow.
+// Race it against a timeout so callers never hang indefinitely.
+function withTimeout(promise, ms, onTimeoutMessage) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      console.error(onTimeoutMessage);
+      resolve(undefined);
+    }, ms);
+
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        console.error(onTimeoutMessage, err);
+        resolve(undefined);
+      },
+    );
+  });
+}
+
+// Read the current canvas state out of the loaded excalidraw.com page's own
+// localStorage (the same keys it already persists itself as the user draws).
+async function readCanvasStateFromWindow(win) {
+  const result = await withTimeout(
+    contentWebContentsFor(win).executeJavaScript(`
+      (function() {
         try {
-          localStorage.setItem("excalidraw", JSON.stringify(${JSON.stringify(elements)}));
-          localStorage.setItem("excalidraw-state", JSON.stringify(${JSON.stringify(appState)}));
-          localStorage.setItem("excalidraw-files", JSON.stringify(${JSON.stringify(files)}));
-          true;
-        } catch(e) {
-          console.error("Failed to inject excalidraw data:", e);
-          false;
+          return {
+            elements: JSON.parse(localStorage.getItem('excalidraw') || '[]'),
+            appState: JSON.parse(localStorage.getItem('excalidraw-state') || '{}'),
+            files: JSON.parse(localStorage.getItem('excalidraw-files') || '{}'),
+          };
+        } catch (e) {
+          return null;
         }
-      `).then(() => {
-        win.webContents.reload();
-      });
-    };
+      })();
+    `),
+    8000,
+    'Timed out or failed reading canvas state from content view:',
+  );
+  return result === undefined ? null : result;
+}
 
-    if (win.webContents.isLoading()) {
-      win.webContents.once('did-finish-load', inject);
-    } else {
-      inject();
+// Dirty-comparison hash deliberately covers only elements + files (the actual
+// drawing content), not appState — appState carries ephemeral UI/view state
+// (scroll position, zoom, welcome-screen flags, etc.) that Excalidraw mutates
+// on its own even with zero user edits, which caused false-positive "unsaved
+// changes" prompts when it was included.
+function hashContent(data) {
+  return hashData({ elements: data.elements, files: data.files });
+}
+
+async function hashCanvasState(win) {
+  const data = await readCanvasStateFromWindow(win);
+  if (data === null) return null;
+  return hashContent(data);
+}
+
+async function hasUnsavedChanges(win) {
+  const state = windowState.get(win.id);
+  if (!state) return false;
+
+  const data = await readCanvasStateFromWindow(win);
+  if (data === null) return false;
+
+  if (state.lastSavedSnapshotHash === null) {
+    // Never saved yet: only consider it dirty if there's actually something drawn.
+    return Array.isArray(data.elements) && data.elements.length > 0;
+  }
+
+  return hashContent(data) !== state.lastSavedSnapshotHash;
+}
+
+// Read a .excalidraw file and inject its contents into the content view via localStorage.
+// Low-level: does not perform any dirty-check. Use openFileInWindow() for that.
+function loadFileIntoWindow(win, filePath) {
+  const contentWebContents = contentWebContentsFor(win);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(safetyTimer);
+      resolve(value);
+    };
+    // Defensive fallback in case 'did-finish-load' never fires after reload()
+    // for some unforeseen reason — without this, the IPC call awaiting this
+    // promise (Save/Open from the sidebar or menu) would hang forever.
+    const safetyTimer = setTimeout(() => {
+      console.error('Timed out waiting for content view to reload:', filePath);
+      settle(false);
+    }, 15000);
+
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const data = JSON.parse(raw);
+
+      const elements = data.elements || [];
+      const appState = data.appState || {};
+      const files = data.files || {};
+
+      // Note: we deliberately don't gate this on contentWebContents.isLoading() —
+      // it can still report true from inside a 'did-finish-load' handler (the very
+      // callers of this function), which would wait on a second did-finish-load
+      // that never fires. executeJavaScript works fine as soon as the DOM/localStorage
+      // exist, and the reload() below re-reads whatever we just set regardless.
+      contentWebContents
+        .executeJavaScript(`
+          try {
+            localStorage.setItem("excalidraw", JSON.stringify(${JSON.stringify(elements)}));
+            localStorage.setItem("excalidraw-state", JSON.stringify(${JSON.stringify(appState)}));
+            localStorage.setItem("excalidraw-files", JSON.stringify(${JSON.stringify(files)}));
+            true;
+          } catch(e) {
+            console.error("Failed to inject excalidraw data:", e);
+            false;
+          }
+        `)
+        .then(() => {
+          contentWebContents.once('did-finish-load', async () => {
+            const state = windowState.get(win.id);
+            if (state) {
+              state.currentFilePath = filePath;
+              state.lastSavedSnapshotHash = await hashCanvasState(win);
+              win.setTitle(`${path.basename(filePath)} — Excalidraw`);
+              notifyCurrentFileChanged(win);
+            }
+            settle(true);
+          });
+          contentWebContents.reload();
+        })
+        .catch((err) => {
+          console.error('Failed to inject .excalidraw file into content view:', err);
+          settle(false);
+        });
+    } catch (err) {
+      console.error('Failed to load .excalidraw file:', err);
+      settle(false);
     }
+  });
+}
+
+// High-level open: checks for unsaved changes first, then reuses loadFileIntoWindow.
+async function openFileInWindow(win, filePath) {
+  if (!win || !filePath) return false;
+
+  if (await hasUnsavedChanges(win)) {
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'warning',
+      buttons: ['Save', "Don't Save", 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      message: 'Do you want to save the changes you made?',
+      detail: "Your changes will be lost if you don't save them.",
+    });
+
+    if (response === 2) return false; // Cancel
+    if (response === 0) {
+      const saved = await saveCurrentWindow(win);
+      if (!saved) return false;
+    }
+  }
+
+  return loadFileIntoWindow(win, filePath);
+}
+
+async function writeCanvasToFile(targetPath, data) {
+  const payload = {
+    type: 'excalidraw',
+    version: 2,
+    source: 'https://excalidraw.com',
+    elements: data.elements,
+    appState: data.appState,
+    files: data.files,
+  };
+  fs.writeFileSync(targetPath, JSON.stringify(payload, null, 2));
+}
+
+async function saveCurrentWindow(win) {
+  const state = windowState.get(win.id);
+  if (!state) return false;
+
+  if (!state.currentFilePath) {
+    return saveAsCurrentWindow(win);
+  }
+
+  const data = await readCanvasStateFromWindow(win);
+  if (!data) {
+    dialog.showErrorBox('Save Failed', 'Could not read the current drawing state.');
+    return false;
+  }
+
+  try {
+    await writeCanvasToFile(state.currentFilePath, data);
+    state.lastSavedSnapshotHash = hashData(data);
+    refreshFileList(win);
+    return true;
   } catch (err) {
-    console.error('Failed to load .excalidraw file:', err);
+    dialog.showErrorBox('Save Failed', err.message || String(err));
+    return false;
   }
 }
 
+async function saveAsCurrentWindow(win) {
+  const state = windowState.get(win.id);
+  if (!state) return false;
+
+  const defaultDir = state.workspaceDir || app.getPath('documents');
+  const { canceled, filePath: chosenPath } = await dialog.showSaveDialog(win, {
+    defaultPath: path.join(defaultDir, 'Untitled.excalidraw'),
+    filters: [{ name: 'Excalidraw Files', extensions: ['excalidraw'] }],
+  });
+
+  if (canceled || !chosenPath) return false;
+
+  const data = await readCanvasStateFromWindow(win);
+  if (!data) {
+    dialog.showErrorBox('Save Failed', 'Could not read the current drawing state.');
+    return false;
+  }
+
+  try {
+    await writeCanvasToFile(chosenPath, data);
+    state.currentFilePath = chosenPath;
+    state.lastSavedSnapshotHash = hashData(data);
+    win.setTitle(`${path.basename(chosenPath)} — Excalidraw`);
+    notifyCurrentFileChanged(win);
+
+    const chosenDir = path.dirname(chosenPath);
+    if (chosenDir !== state.workspaceDir) {
+      setWorkspace(win, chosenDir);
+      saveWorkspaceState({ ...loadWorkspaceState(), lastWorkspaceDir: chosenDir });
+    } else {
+      refreshFileList(win);
+    }
+    return true;
+  } catch (err) {
+    dialog.showErrorBox('Save Failed', err.message || String(err));
+    return false;
+  }
+}
+
+function scanWorkspaceFiles(dir) {
+  if (!dir) return [];
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.excalidraw'))
+      .map((entry) => {
+        const filePath = path.join(dir, entry.name);
+        let mtimeMs = 0;
+        try {
+          mtimeMs = fs.statSync(filePath).mtimeMs;
+        } catch {
+          // Ignore races with concurrent deletion.
+        }
+        return { path: filePath, mtimeMs };
+      })
+      .sort((a, b) => a.path.localeCompare(b.path));
+  } catch (err) {
+    console.error('Failed to scan workspace folder:', err);
+    return [];
+  }
+}
+
+function notifyFilesChanged(win) {
+  const state = windowState.get(win.id);
+  if (!state) return;
+  state.sidebarView.webContents.send('workspace:filesChanged', scanWorkspaceFiles(state.workspaceDir));
+}
+
+function notifyWorkspaceChanged(win) {
+  const state = windowState.get(win.id);
+  if (!state) return;
+  state.sidebarView.webContents.send('workspace:changed', state.workspaceDir);
+}
+
+function notifyCurrentFileChanged(win) {
+  const state = windowState.get(win.id);
+  if (!state) return;
+  state.sidebarView.webContents.send('workspace:currentFileChanged', state.currentFilePath);
+}
+
+function refreshFileList(win) {
+  notifyFilesChanged(win);
+}
+
+function debounceRefresh(dir, entry) {
+  if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+  entry.debounceTimer = setTimeout(() => {
+    entry.debounceTimer = null;
+    for (const winId of entry.subscribers) {
+      const state = windowState.get(winId);
+      if (state) notifyFilesChanged(state.win);
+    }
+  }, 200);
+}
+
+function watchWorkspace(dir, winId) {
+  if (!dir) return;
+
+  const existing = workspaceWatchers.get(dir);
+  if (existing) {
+    existing.subscribers.add(winId);
+    return;
+  }
+
+  const entry = { subscribers: new Set([winId]), debounceTimer: null, watcher: null };
+  try {
+    entry.watcher = fs.watch(dir, { persistent: true }, () => debounceRefresh(dir, entry));
+  } catch (err) {
+    console.error('Failed to watch workspace folder:', err);
+  }
+  workspaceWatchers.set(dir, entry);
+}
+
+function unwatchWorkspace(dir, winId) {
+  if (!dir) return;
+  const entry = workspaceWatchers.get(dir);
+  if (!entry) return;
+
+  entry.subscribers.delete(winId);
+  if (entry.subscribers.size === 0) {
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+    if (entry.watcher) entry.watcher.close();
+    workspaceWatchers.delete(dir);
+  }
+}
+
+function setWorkspace(win, dir) {
+  const state = windowState.get(win.id);
+  if (!state) return;
+
+  if (state.workspaceDir && state.workspaceDir !== dir) {
+    unwatchWorkspace(state.workspaceDir, win.id);
+  }
+
+  state.workspaceDir = dir || null;
+
+  if (state.workspaceDir) {
+    watchWorkspace(state.workspaceDir, win.id);
+  }
+
+  notifyWorkspaceChanged(win);
+  notifyFilesChanged(win);
+}
+
+async function chooseWorkspaceFolder(win) {
+  if (!win) return;
+  const { canceled, filePaths } = await dialog.showOpenDialog(win, {
+    properties: ['openDirectory'],
+  });
+  if (canceled || !filePaths || !filePaths[0]) return;
+
+  const dir = filePaths[0];
+  setWorkspace(win, dir);
+  saveWorkspaceState({ ...loadWorkspaceState(), lastWorkspaceDir: dir });
+}
+
+async function openFileDialogInWindow(win) {
+  if (!win) return;
+  const { canceled, filePaths } = await dialog.showOpenDialog(win, {
+    properties: ['openFile'],
+    filters: [{ name: 'Excalidraw Files', extensions: ['excalidraw'] }],
+  });
+  if (canceled || !filePaths[0]) return;
+  await openFileInWindow(win, filePaths[0]);
+}
+
+function computeNewFilePath(dir) {
+  let candidate = path.join(dir, 'Untitled.excalidraw');
+  let counter = 2;
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(dir, `Untitled (${counter}).excalidraw`);
+    counter += 1;
+  }
+  return candidate;
+}
+
+async function createNewFileInWindow(win) {
+  const state = windowState.get(win.id);
+  if (!state || !state.workspaceDir) return false;
+
+  const newPath = computeNewFilePath(state.workspaceDir);
+  const skeleton = {
+    type: 'excalidraw',
+    version: 2,
+    source: 'https://excalidraw.com',
+    elements: [],
+    appState: {},
+    files: {},
+  };
+
+  try {
+    fs.writeFileSync(newPath, JSON.stringify(skeleton, null, 2));
+  } catch (err) {
+    dialog.showErrorBox('New File Failed', err.message || String(err));
+    return false;
+  }
+
+  refreshFileList(win);
+  return openFileInWindow(win, newPath);
+}
+
+function sanitizeFileName(name) {
+  const stripped = String(name || '')
+    .replace(/[\\/:*?"<>|]/g, '')
+    .trim();
+  if (!stripped) return '';
+  return stripped.endsWith('.excalidraw') ? stripped : `${stripped}.excalidraw`;
+}
+
+async function renameFileInWindow(win, oldPath, newName) {
+  const state = windowState.get(win.id);
+  if (!state || !state.workspaceDir) return false;
+
+  const sanitized = sanitizeFileName(newName);
+  if (!sanitized || sanitized === '.excalidraw') return false;
+
+  const newPath = path.join(state.workspaceDir, sanitized);
+  if (newPath === oldPath) return true;
+
+  if (fs.existsSync(newPath)) {
+    dialog.showErrorBox('Rename Failed', `A file named "${sanitized}" already exists.`);
+    return false;
+  }
+
+  try {
+    fs.renameSync(oldPath, newPath);
+  } catch (err) {
+    dialog.showErrorBox('Rename Failed', err.message || String(err));
+    return false;
+  }
+
+  if (state.currentFilePath === oldPath) {
+    state.currentFilePath = newPath;
+    win.setTitle(`${path.basename(newPath)} — Excalidraw`);
+    notifyCurrentFileChanged(win);
+  }
+
+  refreshFileList(win);
+  return true;
+}
+
+async function deleteFileInWindow(win, filePath) {
+  const { response } = await dialog.showMessageBox(win, {
+    type: 'warning',
+    buttons: ['Move to Trash', 'Cancel'],
+    defaultId: 1,
+    cancelId: 1,
+    message: `Delete "${path.basename(filePath)}"?`,
+    detail: 'The file will be moved to the trash.',
+  });
+  if (response !== 0) return false;
+
+  try {
+    await shell.trashItem(filePath);
+  } catch (err) {
+    dialog.showErrorBox('Delete Failed', err.message || String(err));
+    return false;
+  }
+
+  const state = windowState.get(win.id);
+  if (state) {
+    if (state.currentFilePath === filePath) {
+      state.currentFilePath = null;
+      win.setTitle('Excalidraw');
+      notifyCurrentFileChanged(win);
+    }
+    refreshFileList(win);
+  }
+  return true;
+}
+
+function layoutViews(win) {
+  const state = windowState.get(win.id);
+  if (!state) return;
+
+  const { width, height } = win.getContentBounds();
+
+  if (state.sidebarVisible) {
+    state.sidebarView.setBounds({ x: 0, y: 0, width: SIDEBAR_WIDTH, height });
+    state.contentView.setBounds({ x: SIDEBAR_WIDTH, y: 0, width: Math.max(0, width - SIDEBAR_WIDTH), height });
+  } else {
+    state.contentView.setBounds({ x: 0, y: 0, width, height });
+  }
+}
+
+function toggleSidebar(win) {
+  if (!win) return;
+  const state = windowState.get(win.id);
+  if (!state) return;
+
+  state.sidebarVisible = !state.sidebarVisible;
+
+  if (state.sidebarVisible) {
+    win.contentView.addChildView(state.sidebarView);
+  } else {
+    win.contentView.removeChildView(state.sidebarView);
+  }
+
+  layoutViews(win);
+  saveWorkspaceState({ ...loadWorkspaceState(), sidebarVisible: state.sidebarVisible });
+}
+
 function createWindow(filePath) {
-  const windowState = loadWindowState();
+  const savedWindowState = loadWindowState();
+  const workspacePrefs = loadWorkspaceState();
+
   const win = new BrowserWindow({
     ...DEFAULT_WINDOW_BOUNDS,
-    ...windowState.bounds,
+    ...savedWindowState.bounds,
+  });
+
+  if (savedWindowState.isMaximized) {
+    win.maximize();
+  }
+
+  const contentView = new WebContentsView({
     webPreferences: {
       nodeIntegration: true,
     },
   });
 
-  if (windowState.isMaximized) {
-    win.maximize();
-  }
-
-  win.on('close', () => {
-    saveWindowState(win);
+  const sidebarView = new WebContentsView({
+    webPreferences: {
+      preload: path.join(__dirname, 'sidebar', 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
   });
 
-  win.loadURL('https://excalidraw.com/');
+  const sidebarVisible = workspacePrefs.sidebarVisible !== false;
+
+  windowState.set(win.id, {
+    win,
+    contentView,
+    sidebarView,
+    sidebarVisible,
+    workspaceDir: null,
+    currentFilePath: null,
+    lastSavedSnapshotHash: null,
+    forceClosing: false,
+  });
+
+  if (sidebarVisible) {
+    win.contentView.addChildView(sidebarView);
+  }
+  win.contentView.addChildView(contentView);
+
+  sidebarView.webContents.loadFile(path.join(__dirname, 'sidebar', 'index.html'));
+  contentView.webContents.loadURL('https://excalidraw.com/');
+
+  layoutViews(win);
+  win.on('resize', () => layoutViews(win));
 
   // Hide menu bar visually for Windows and Linux, but keep keyboard shortcuts working
   if (process.platform === 'win32' || process.platform === 'linux') {
@@ -330,15 +881,119 @@ function createWindow(filePath) {
     win.setAutoHideMenuBar(true);
   }
 
+  const initialWorkspaceDir = filePath
+    ? path.dirname(filePath)
+    : workspacePrefs.lastWorkspaceDir && fs.existsSync(workspacePrefs.lastWorkspaceDir)
+      ? workspacePrefs.lastWorkspaceDir
+      : null;
+
+  setWorkspace(win, initialWorkspaceDir);
+
   // If a file was requested, load it once the page is ready
   if (filePath) {
-    win.webContents.once('did-finish-load', () => {
+    contentView.webContents.once('did-finish-load', () => {
       loadFileIntoWindow(win, filePath);
     });
   }
 
+  contentView.webContents.once('did-finish-load', () => {
+    contentView.webContents.focus();
+  });
+
+  win.on('close', (event) => {
+    const state = windowState.get(win.id);
+    if (!state || state.forceClosing) {
+      return;
+    }
+
+    event.preventDefault();
+
+    (async () => {
+      if (await hasUnsavedChanges(win)) {
+        const { response } = await dialog.showMessageBox(win, {
+          type: 'warning',
+          buttons: ['Save', "Don't Save", 'Cancel'],
+          defaultId: 0,
+          cancelId: 2,
+          message: 'Do you want to save the changes you made?',
+          detail: "Your changes will be lost if you don't save them.",
+        });
+
+        if (response === 2) return; // Cancel
+        if (response === 0) {
+          const saved = await saveCurrentWindow(win);
+          if (!saved) return;
+        }
+      }
+
+      saveWindowState(win);
+      state.forceClosing = true;
+      win.close();
+    })();
+  });
+
+  win.on('closed', () => {
+    const state = windowState.get(win.id);
+    if (state && state.workspaceDir) {
+      unwatchWorkspace(state.workspaceDir, win.id);
+    }
+    windowState.delete(win.id);
+  });
+
   return win;
 }
+
+ipcMain.handle('workspace:selectFolder', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (win) await chooseWorkspaceFolder(win);
+});
+
+ipcMain.handle('workspace:getState', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const state = win && windowState.get(win.id);
+  if (!state) return { workspaceDir: null, files: [], currentFilePath: null };
+  return {
+    workspaceDir: state.workspaceDir,
+    files: scanWorkspaceFiles(state.workspaceDir),
+    currentFilePath: state.currentFilePath,
+  };
+});
+
+ipcMain.handle('file:open', async (event, filePath) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return openFileInWindow(win, filePath);
+});
+
+ipcMain.handle('file:new', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return createNewFileInWindow(win);
+});
+
+ipcMain.handle('file:rename', async (event, { oldPath, newName }) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return renameFileInWindow(win, oldPath, newName);
+});
+
+ipcMain.handle('file:delete', async (event, filePath) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return deleteFileInWindow(win, filePath);
+});
+
+ipcMain.handle('file:save', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return saveCurrentWindow(win);
+});
+
+ipcMain.handle('file:saveAs', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  return saveAsCurrentWindow(win);
+});
 
 // macOS: open-file fires when a file is double-clicked or dragged onto the dock icon
 // This can fire BEFORE app 'ready', so we store the path for later
@@ -422,6 +1077,62 @@ const template = [
         },
       ]
     : []),
+  {
+    label: 'File',
+    submenu: [
+      {
+        label: 'New File',
+        accelerator: 'CmdOrCtrl+N',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) void createNewFileInWindow(win);
+        },
+      },
+      { type: 'separator' },
+      {
+        label: 'Open File...',
+        accelerator: 'CmdOrCtrl+O',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) void openFileDialogInWindow(win);
+        },
+      },
+      {
+        label: 'Open Folder...',
+        accelerator: 'CmdOrCtrl+Shift+O',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) void chooseWorkspaceFolder(win);
+        },
+      },
+      { type: 'separator' },
+      {
+        label: 'Save',
+        accelerator: 'CmdOrCtrl+S',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) void saveCurrentWindow(win);
+        },
+      },
+      {
+        label: 'Save As...',
+        accelerator: 'CmdOrCtrl+Shift+S',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) void saveAsCurrentWindow(win);
+        },
+      },
+      { type: 'separator' },
+      {
+        label: 'Toggle Sidebar',
+        accelerator: 'CmdOrCtrl+B',
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) toggleSidebar(win);
+        },
+      },
+    ],
+  },
   {
     label: 'Edit',
     submenu: [

--- a/index.js
+++ b/index.js
@@ -375,6 +375,28 @@ async function hashCanvasState(win) {
   return hashContent(data);
 }
 
+// Right after a fresh load/reload, excalidraw.com's own app can still be
+// restoring/normalizing elements and re-writing them to localStorage via its
+// debounced autosave for a brief moment after 'did-finish-load' fires. Hashing
+// immediately can capture a pre-normalization snapshot as the baseline, which
+// will then never match the (already-normalized) live state read on the next
+// dirty-check — a false-positive "unsaved changes" prompt on the very next
+// file switch. Poll until two consecutive reads agree (or give up) so the
+// baseline reflects the settled state.
+async function waitForStableCanvasHash(win, { intervalMs = 150, maxWaitMs = 1500 } = {}) {
+  let previous = await hashCanvasState(win);
+  const deadline = Date.now() + maxWaitMs;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    const current = await hashCanvasState(win);
+    if (current === previous) return current;
+    previous = current;
+  }
+
+  return previous;
+}
+
 async function hasUnsavedChanges(win) {
   const state = windowState.get(win.id);
   if (!state) return false;
@@ -456,7 +478,7 @@ function loadFileIntoWindow(win, filePath) {
             const state = windowState.get(win.id);
             if (state) {
               state.currentFilePath = filePath;
-              state.lastSavedSnapshotHash = await hashCanvasState(win);
+              state.lastSavedSnapshotHash = await waitForStableCanvasHash(win);
               win.setTitle(`${path.basename(filePath)} — Excalidraw`);
               notifyCurrentFileChanged(win);
             }
@@ -527,7 +549,7 @@ async function saveCurrentWindow(win) {
 
   try {
     await writeCanvasToFile(state.currentFilePath, data);
-    state.lastSavedSnapshotHash = hashData(data);
+    state.lastSavedSnapshotHash = hashContent(data);
     refreshFileList(win);
     return true;
   } catch (err) {
@@ -557,7 +579,7 @@ async function saveAsCurrentWindow(win) {
   try {
     await writeCanvasToFile(chosenPath, data);
     state.currentFilePath = chosenPath;
-    state.lastSavedSnapshotHash = hashData(data);
+    state.lastSavedSnapshotHash = hashContent(data);
     win.setTitle(`${path.basename(chosenPath)} — Excalidraw`);
     notifyCurrentFileChanged(win);
 
@@ -908,6 +930,25 @@ function createWindow(filePath) {
   if (filePath) {
     contentView.webContents.once('did-finish-load', () => {
       loadFileIntoWindow(win, filePath);
+    });
+  } else {
+    // A brand-new window with no file yet still loads excalidraw.com's last
+    // persisted localStorage content — it's the same session/profile shared
+    // across windows and app restarts, so leftover elements from a previous
+    // drawing can still be sitting there. Since no file is loaded yet,
+    // hasUnsavedChanges() falls into its "never saved" check (elements.length
+    // > 0), which would then see that leftover content and show a
+    // false-positive save prompt the first time this window opens/creates a
+    // file, even though nothing was drawn here. Clear it so a fresh window
+    // actually starts blank.
+    contentView.webContents.once('did-finish-load', () => {
+      contentView.webContents.executeJavaScript(`
+        try {
+          localStorage.setItem("excalidraw", "[]");
+          localStorage.setItem("excalidraw-state", "{}");
+          localStorage.setItem("excalidraw-files", "{}");
+        } catch (e) {}
+      `);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -901,6 +901,25 @@ function createWindow(filePath) {
     forceClosing: false,
   });
 
+  // Intercept Ctrl+S at the webContents level: on Linux/Windows the menu bar is
+  // hidden, which breaks Electron's menu-accelerator dispatch, so CmdOrCtrl+S
+  // would otherwise fall through to excalidraw.com's own Ctrl+S handler.
+  const handleSaveShortcut = (event, input) => {
+    if (input.type !== 'keyDown' || input.isAutoRepeat) return;
+    if (!(input.control || input.meta) || input.alt) return;
+    if (input.key.toLowerCase() !== 's') return;
+
+    event.preventDefault();
+    if (input.shift) {
+      void saveAsCurrentWindow(win);
+    } else {
+      void saveCurrentWindow(win);
+    }
+  };
+
+  contentView.webContents.on('before-input-event', handleSaveShortcut);
+  sidebarView.webContents.on('before-input-event', handleSaveShortcut);
+
   if (sidebarVisible) {
     win.contentView.addChildView(sidebarView);
   }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ let updateCheckPromise = null;
 const windowState = new Map();
 // Per-directory watchers, refcounted across windows: dir -> { watcher, subscribers: Set<winId>, debounceTimer }
 const workspaceWatchers = new Map();
+// In-flight New File dialogs, keyed by the dialog window's webContents.id: -> { resolve, existingNames }
+const pendingNewFileDialogs = new Map();
 
 function normalizeVersion(version) {
   return String(version || '')
@@ -724,21 +726,138 @@ async function openFileDialogInWindow(win) {
   await openFileInWindow(win, filePaths[0]);
 }
 
-function computeNewFilePath(dir) {
-  let candidate = path.join(dir, 'Untitled.excalidraw');
+const ILLEGAL_FILENAME_CHARS_REGEX = /[\\/:*?"<>|\x00-\x1F]/g;
+const WINDOWS_RESERVED_NAMES = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+]);
+const MAX_BASENAME_LENGTH = 150;
+
+// Includes time down to the second so repeated "New File" calls in the same
+// minute (e.g. blank-name submits) don't collide and fall through to the
+// " (2)", " (3)", ... suffix.
+function formatDateForFilename(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+}
+
+// Sanitizes a user-supplied base name (no extension) for use as a filename.
+// Returns '' if nothing usable remains; callers decide the fallback.
+function sanitizeBaseName(name) {
+  let result = String(name || '').replace(ILLEGAL_FILENAME_CHARS_REGEX, '');
+  result = result.replace(/\.excalidraw$/i, '');
+  // Windows silently drops trailing dots/spaces from the actual filename on disk,
+  // which would otherwise desync what's shown from what's created.
+  result = result.trim().replace(/[. ]+$/, '');
+  if (!result) return '';
+  if (WINDOWS_RESERVED_NAMES.has(result.toUpperCase())) return '';
+  return result.slice(0, MAX_BASENAME_LENGTH);
+}
+
+function ensureExcalidrawExtension(name) {
+  return name.endsWith('.excalidraw') ? name : `${name}.excalidraw`;
+}
+
+function computeNewFilePath(dir, baseName) {
+  const sanitized = sanitizeBaseName(baseName) || 'Untitled';
+  let candidate = path.join(dir, ensureExcalidrawExtension(sanitized));
   let counter = 2;
   while (fs.existsSync(candidate)) {
-    candidate = path.join(dir, `Untitled (${counter}).excalidraw`);
+    candidate = path.join(dir, `${sanitized} (${counter}).excalidraw`);
     counter += 1;
   }
   return candidate;
+}
+
+// Shows a small modal BrowserWindow prompting for a new file's base name.
+// Resolves the entered name, or null if the dialog was cancelled/closed.
+function promptForNewFileName(parentWin, defaultName, existingNames) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const dialogWin = new BrowserWindow({
+      width: 420,
+      height: 220,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      modal: true,
+      parent: parentWin,
+      show: false,
+      title: 'New File',
+      webPreferences: {
+        preload: path.join(__dirname, 'dialogs', 'new-file-preload.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    // Windows/Linux would otherwise inherit the app's full menu bar on this tiny window.
+    dialogWin.setMenu(null);
+
+    // Captured up front: by the time 'closed' fires, dialogWin.webContents has
+    // already been destroyed, so re-reading .webContents.id there throws.
+    const webContentsId = dialogWin.webContents.id;
+    pendingNewFileDialogs.set(webContentsId, { resolve: settle, existingNames });
+
+    dialogWin.on('closed', () => {
+      pendingNewFileDialogs.delete(webContentsId);
+      settle(null);
+    });
+
+    dialogWin.once('ready-to-show', () => dialogWin.show());
+
+    dialogWin.loadFile(path.join(__dirname, 'dialogs', 'new-file-dialog.html'), {
+      query: { default: defaultName },
+    });
+  });
 }
 
 async function createNewFileInWindow(win) {
   const state = windowState.get(win.id);
   if (!state || !state.workspaceDir) return false;
 
-  const newPath = computeNewFilePath(state.workspaceDir);
+  const defaultName = `drawing_${formatDateForFilename()}`;
+  const existingNames = fs
+    .readdirSync(state.workspaceDir)
+    .filter((f) => f.endsWith('.excalidraw'))
+    .map((f) => f.slice(0, -'.excalidraw'.length).toLowerCase());
+  const inputName = await promptForNewFileName(win, defaultName, existingNames);
+  if (inputName === null) return false; // user cancelled
+
+  const baseName = inputName.trim() || defaultName;
+  const newPath = computeNewFilePath(state.workspaceDir, baseName);
   const skeleton = {
     type: 'excalidraw',
     version: 2,
@@ -760,11 +879,9 @@ async function createNewFileInWindow(win) {
 }
 
 function sanitizeFileName(name) {
-  const stripped = String(name || '')
-    .replace(/[\\/:*?"<>|]/g, '')
-    .trim();
-  if (!stripped) return '';
-  return stripped.endsWith('.excalidraw') ? stripped : `${stripped}.excalidraw`;
+  const sanitized = sanitizeBaseName(name);
+  if (!sanitized) return '';
+  return ensureExcalidrawExtension(sanitized);
 }
 
 async function renameFileInWindow(win, oldPath, newName) {
@@ -1068,6 +1185,26 @@ ipcMain.handle('file:saveAs', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!win) return false;
   return saveAsCurrentWindow(win);
+});
+
+ipcMain.handle('dialog:new-file-submit', (event, name) => {
+  const entry = pendingNewFileDialogs.get(event.sender.id);
+  if (!entry) return;
+  pendingNewFileDialogs.delete(event.sender.id);
+  entry.resolve(name);
+  BrowserWindow.fromWebContents(event.sender)?.close();
+});
+
+ipcMain.handle('dialog:new-file-cancel', (event) => {
+  const entry = pendingNewFileDialogs.get(event.sender.id);
+  if (!entry) return;
+  pendingNewFileDialogs.delete(event.sender.id);
+  entry.resolve(null);
+  BrowserWindow.fromWebContents(event.sender)?.close();
+});
+
+ipcMain.handle('dialog:new-file-getExistingNames', (event) => {
+  return pendingNewFileDialogs.get(event.sender.id)?.existingNames ?? [];
 });
 
 // macOS: open-file fires when a file is double-clicked or dragged onto the dock icon

--- a/index.js
+++ b/index.js
@@ -424,12 +424,27 @@ function loadFileIntoWindow(win, filePath) {
       // callers of this function), which would wait on a second did-finish-load
       // that never fires. executeJavaScript works fine as soon as the DOM/localStorage
       // exist, and the reload() below re-reads whatever we just set regardless.
+      //
+      // excalidraw.com flushes its own pending debounced autosave synchronously
+      // on 'beforeunload'/'unload' (LocalData.flushSave() in its App.tsx), which
+      // fires the instant reload() below starts navigating away — i.e. strictly
+      // AFTER we've written here. If a save was still pending (which is common,
+      // since its debounce resets on nearly any interaction, including moving
+      // the mouse toward the button that got us here), that flush silently
+      // overwrites what we just wrote with stale pre-navigation elements/appState.
+      // No delay before writing can avoid this, since the flush is triggered by
+      // navigating away, not by a fixed timer. So instead we neutralize further
+      // localStorage writes right after our own, making that flush a no-op —
+      // excalidraw.com calls localStorage.setItem() directly (not a cached
+      // reference), so overriding it here reliably intercepts it.
       contentWebContents
         .executeJavaScript(`
           try {
-            localStorage.setItem("excalidraw", JSON.stringify(${JSON.stringify(elements)}));
-            localStorage.setItem("excalidraw-state", JSON.stringify(${JSON.stringify(appState)}));
-            localStorage.setItem("excalidraw-files", JSON.stringify(${JSON.stringify(files)}));
+            const setItem = Storage.prototype.setItem.bind(localStorage);
+            localStorage.setItem = function () {};
+            setItem("excalidraw", JSON.stringify(${JSON.stringify(elements)}));
+            setItem("excalidraw-state", JSON.stringify(${JSON.stringify(appState)}));
+            setItem("excalidraw-files", JSON.stringify(${JSON.stringify(files)}));
             true;
           } catch(e) {
             console.error("Failed to inject excalidraw data:", e);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       "build/**/*",
       "node_modules/**/*",
       "sidebar/**/*",
+      "dialogs/**/*",
       "index.js",
       "package.json"
     ],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "files": [
       "build/**/*",
       "node_modules/**/*",
+      "sidebar/**/*",
       "index.js",
       "package.json"
     ],

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self';"
+    />
+    <title>Files</title>
+    <link rel="stylesheet" href="sidebar.css" />
+  </head>
+  <body>
+    <div class="sidebar">
+      <div class="workspace-header">
+        <span id="workspace-name" class="workspace-name" title="">No folder selected</span>
+        <button id="change-folder-btn" class="icon-btn" title="Choose folder">📁</button>
+      </div>
+
+      <div class="toolbar">
+        <button id="new-file-btn" class="new-file-btn" disabled>+ New File</button>
+      </div>
+
+      <div id="empty-state" class="empty-state">
+        <p>No folder selected.</p>
+        <button id="choose-folder-btn">Choose Folder</button>
+      </div>
+
+      <ul id="file-list" class="file-list"></ul>
+    </div>
+
+    <script src="sidebar.js"></script>
+  </body>
+</html>

--- a/sidebar/preload.js
+++ b/sidebar/preload.js
@@ -1,0 +1,23 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('workspaceAPI', {
+  getInitialState: () => ipcRenderer.invoke('workspace:getState'),
+  selectFolder: () => ipcRenderer.invoke('workspace:selectFolder'),
+
+  openFile: (filePath) => ipcRenderer.invoke('file:open', filePath),
+  newFile: () => ipcRenderer.invoke('file:new'),
+  renameFile: (oldPath, newName) => ipcRenderer.invoke('file:rename', { oldPath, newName }),
+  deleteFile: (filePath) => ipcRenderer.invoke('file:delete', filePath),
+  saveCurrent: () => ipcRenderer.invoke('file:save'),
+  saveCurrentAs: () => ipcRenderer.invoke('file:saveAs'),
+
+  onFilesChanged: (cb) => {
+    ipcRenderer.on('workspace:filesChanged', (_event, files) => cb(files));
+  },
+  onWorkspaceChanged: (cb) => {
+    ipcRenderer.on('workspace:changed', (_event, dir) => cb(dir));
+  },
+  onCurrentFileChanged: (cb) => {
+    ipcRenderer.on('workspace:currentFileChanged', (_event, filePath) => cb(filePath));
+  },
+});

--- a/sidebar/sidebar.css
+++ b/sidebar/sidebar.css
@@ -1,0 +1,187 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f7;
+  --fg: #1e1e1e;
+  --border: #dcdcdc;
+  --hover: #e8e8ec;
+  --active: #dbe6ff;
+  --active-fg: #1a3d8f;
+  --muted: #7a7a7a;
+  --danger: #c0392b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #202124;
+    --fg: #e8e8e8;
+    --border: #35363a;
+    --hover: #2b2c30;
+    --active: #2a3b5c;
+    --active-fg: #9cc0ff;
+    --muted: #9a9a9a;
+    --danger: #ff6b5e;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg);
+  font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.workspace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  gap: 8px;
+}
+
+.workspace-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: var(--fg);
+}
+
+.icon-btn:hover {
+  background: var(--hover);
+}
+
+.toolbar {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.new-file-btn,
+#choose-folder-btn {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--hover);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.new-file-btn:hover,
+#choose-folder-btn:hover {
+  background: var(--active);
+}
+
+.new-file-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--muted);
+  display: none;
+}
+
+.empty-state p {
+  margin: 0 0 12px;
+}
+
+.file-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  margin: 0 4px;
+}
+
+.file-row:hover {
+  background: var(--hover);
+}
+
+.file-row.active {
+  background: var(--active);
+  color: var(--active-fg);
+  font-weight: 600;
+}
+
+.file-row .file-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-row .file-actions {
+  display: none;
+  gap: 2px;
+}
+
+.file-row:hover .file-actions {
+  display: flex;
+}
+
+.file-row .file-actions button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  color: var(--muted);
+}
+
+.file-row .file-actions button:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+
+.file-row .rename-input {
+  flex: 1;
+  font: inherit;
+  padding: 2px 4px;
+  border: 1px solid var(--active-fg);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.no-files {
+  padding: 16px;
+  text-align: center;
+  color: var(--muted);
+}

--- a/sidebar/sidebar.js
+++ b/sidebar/sidebar.js
@@ -1,0 +1,145 @@
+(function () {
+  const workspaceNameEl = document.getElementById('workspace-name');
+  const changeFolderBtn = document.getElementById('change-folder-btn');
+  const chooseFolderBtn = document.getElementById('choose-folder-btn');
+  const newFileBtn = document.getElementById('new-file-btn');
+  const emptyStateEl = document.getElementById('empty-state');
+  const fileListEl = document.getElementById('file-list');
+
+  let currentFiles = [];
+  let currentFilePath = null;
+  let editingPath = null;
+
+  function basename(filePath) {
+    if (!filePath) return '';
+    return filePath.replace(/\\/g, '/').split('/').pop();
+  }
+
+  function renderWorkspaceHeader(workspaceDir) {
+    const hasWorkspace = Boolean(workspaceDir);
+    workspaceNameEl.textContent = hasWorkspace ? basename(workspaceDir) : 'No folder selected';
+    workspaceNameEl.title = hasWorkspace ? workspaceDir : '';
+    newFileBtn.disabled = !hasWorkspace;
+    emptyStateEl.style.display = hasWorkspace ? 'none' : 'block';
+    fileListEl.style.display = hasWorkspace ? 'block' : 'none';
+  }
+
+  function makeFileRow(file) {
+    const li = document.createElement('li');
+    li.className = 'file-row' + (file.path === currentFilePath ? ' active' : '');
+    li.dataset.path = file.path;
+
+    if (editingPath === file.path) {
+      const input = document.createElement('input');
+      input.className = 'rename-input';
+      input.value = basename(file.path);
+      input.addEventListener('click', (e) => e.stopPropagation());
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          commitRename(file.path, input.value);
+        } else if (e.key === 'Escape') {
+          editingPath = null;
+          renderFileList(currentFiles);
+        }
+      });
+      input.addEventListener('blur', () => {
+        if (editingPath === file.path) {
+          commitRename(file.path, input.value);
+        }
+      });
+      li.appendChild(input);
+      queueMicrotask(() => {
+        input.focus();
+        input.select();
+      });
+      return li;
+    }
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'file-name';
+    nameSpan.textContent = basename(file.path);
+    li.appendChild(nameSpan);
+
+    const actions = document.createElement('span');
+    actions.className = 'file-actions';
+
+    const renameBtn = document.createElement('button');
+    renameBtn.textContent = '✏️';
+    renameBtn.title = 'Rename';
+    renameBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      editingPath = file.path;
+      renderFileList(currentFiles);
+    });
+    actions.appendChild(renameBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = '🗑';
+    deleteBtn.title = 'Delete';
+    deleteBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      window.workspaceAPI.deleteFile(file.path);
+    });
+    actions.appendChild(deleteBtn);
+
+    li.appendChild(actions);
+
+    li.addEventListener('click', () => {
+      window.workspaceAPI.openFile(file.path);
+    });
+
+    return li;
+  }
+
+  function commitRename(oldPath, rawName) {
+    editingPath = null;
+    const trimmed = rawName.trim();
+    if (trimmed && trimmed !== basename(oldPath)) {
+      window.workspaceAPI.renameFile(oldPath, trimmed);
+    } else {
+      renderFileList(currentFiles);
+    }
+  }
+
+  function renderFileList(files) {
+    currentFiles = files || [];
+    fileListEl.innerHTML = '';
+
+    if (currentFiles.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'no-files';
+      li.textContent = 'No .excalidraw files in this folder.';
+      fileListEl.appendChild(li);
+      return;
+    }
+
+    for (const file of currentFiles) {
+      fileListEl.appendChild(makeFileRow(file));
+    }
+  }
+
+  function highlightActiveFile(filePath) {
+    currentFilePath = filePath;
+    renderFileList(currentFiles);
+  }
+
+  changeFolderBtn.addEventListener('click', () => window.workspaceAPI.selectFolder());
+  chooseFolderBtn.addEventListener('click', () => window.workspaceAPI.selectFolder());
+  newFileBtn.addEventListener('click', () => window.workspaceAPI.newFile());
+
+  window.workspaceAPI.onWorkspaceChanged((workspaceDir) => {
+    renderWorkspaceHeader(workspaceDir);
+    if (!workspaceDir) {
+      renderFileList([]);
+    }
+  });
+  window.workspaceAPI.onFilesChanged((files) => renderFileList(files));
+  window.workspaceAPI.onCurrentFileChanged((filePath) => highlightActiveFile(filePath));
+
+  window.workspaceAPI.getInitialState().then((state) => {
+    if (!state) return;
+    currentFilePath = state.currentFilePath || null;
+    renderWorkspaceHeader(state.workspaceDir);
+    renderFileList(state.files);
+  });
+})();


### PR DESCRIPTION
- Adds a persistent sidebar for browsing a workspace folder's .excalidraw files — open, rename, and delete files without leaving the app; new IPC channels connect the sidebar UI to file-system operations in the main process.
- Makes canvas reloads (New File/Open/switch) reliably show the target file's content: excalidraw.com's own debounced autosave was flushing on beforeunload, overwriting our just-written data with stale pre-navigation state, so localStorage.setItem is now neutralized right after our write to make that flush a no-op.
- Aligns the save and dirty-check hashing (both now cover elements + appState + files) so the "unsaved changes" prompt reflects actual state instead of always looking dirty after a save; also ensures a fresh window doesn't inherit stale canvas content from a previous session sharing localStorage.
- Handles Ctrl+S via before-input-event instead of relying on the (hidden, on Linux/Windows) menu bar's accelerator dispatch, so it reliably saves in place instead of falling through to excalidraw.com's own Save As prompt.
- Adds a "New File" naming dialog: prompts for a name with a live sanitized-filename preview and collision warning (auto-appends  (2),  (3), ...), replacing the fixed Untitled.excalidraw default.
- Packages the new dialogs/**/* assets in electron-builder's file list so the New File dialog works in packaged builds, not just npm start.